### PR TITLE
+tck #181 provides default helperPublisher for subscriber tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: java
 script:
-- ./gradlew check
+  - ./gradlew check
 cache:
   directories:
   - $HOME/.gradle
 jdk:
-- openjdk6
+  - openjdk6
 env:
   global:
   - TERM=dumb

--- a/examples/src/main/java/org/reactivestreams/example/unicast/AsyncSubscriber.java
+++ b/examples/src/main/java/org/reactivestreams/example/unicast/AsyncSubscriber.java
@@ -1,6 +1,5 @@
 package org.reactivestreams.example.unicast;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 

--- a/examples/src/main/java/org/reactivestreams/example/unicast/SyncSubscriber.java
+++ b/examples/src/main/java/org/reactivestreams/example/unicast/SyncSubscriber.java
@@ -1,6 +1,5 @@
 package org.reactivestreams.example.unicast;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 

--- a/examples/src/test/java/org/reactivestreams/example/unicast/AsyncSubscriberTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/AsyncSubscriberTest.java
@@ -17,14 +17,14 @@ import java.util.concurrent.TimeUnit;
 
 @Test // Must be here for TestNG to find and run this, do not remove
 public class AsyncSubscriberTest extends SubscriberBlackboxVerification<Integer> {
-  final static long DefaultTimeoutMillis = 100;
+  final static long DEFAULT_TIMEOUT_MILLIS = 100;
 
   private ExecutorService e;
   @BeforeClass void before() { e = Executors.newFixedThreadPool(4); }
   @AfterClass void after() { if (e != null) e.shutdown(); }
 
   public AsyncSubscriberTest() {
-    super(new TestEnvironment(DefaultTimeoutMillis));
+    super(new TestEnvironment(DEFAULT_TIMEOUT_MILLIS));
   }
 
   @Override public Subscriber<Integer> createSubscriber() {
@@ -53,11 +53,15 @@ public class AsyncSubscriberTest extends SubscriberBlackboxVerification<Integer>
     };
 
     new NumberIterablePublisher(0, 10, e).subscribe(sub);
-    latch.await(DefaultTimeoutMillis * 10, TimeUnit.MILLISECONDS);
+    latch.await(DEFAULT_TIMEOUT_MILLIS * 10, TimeUnit.MILLISECONDS);
     assertEquals(i.get(), 45);
   }
 
   @Override public Integer createElement(int element) {
     return element;
+  }
+
+  @Override public Publisher<Integer> createHelperPublisher(long elements) {
+    return super.createHelperPublisher(elements);
   }
 }

--- a/examples/src/test/java/org/reactivestreams/example/unicast/AsyncSubscriberTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/AsyncSubscriberTest.java
@@ -1,7 +1,5 @@
 package org.reactivestreams.example.unicast;
 
-import java.util.Collections;
-import java.util.Iterator;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.tck.SubscriberBlackboxVerification;
@@ -31,16 +29,10 @@ public class AsyncSubscriberTest extends SubscriberBlackboxVerification<Integer>
 
   @Override public Subscriber<Integer> createSubscriber() {
     return new AsyncSubscriber<Integer>(e) {
-      private long acc;
       @Override protected boolean whenNext(final Integer element) {
         return true;
       }
     };
-  }
-  @SuppressWarnings("unchecked")
-  @Override public Publisher<Integer> createHelperPublisher(long elements) {
-    if (elements > Integer.MAX_VALUE) return new InfiniteIncrementNumberPublisher(e);
-    else return new NumberIterablePublisher(0, (int)elements, e);
   }
 
   @Test public void testAccumulation() throws InterruptedException {
@@ -60,8 +52,12 @@ public class AsyncSubscriberTest extends SubscriberBlackboxVerification<Integer>
       }
     };
 
-    new NumberIterablePublisher<Integer>(0, 10, e).subscribe(sub);
+    new NumberIterablePublisher(0, 10, e).subscribe(sub);
     latch.await(DefaultTimeoutMillis * 10, TimeUnit.MILLISECONDS);
     assertEquals(i.get(), 45);
+  }
+
+  @Override public Integer createElement(int element) {
+    return element;
   }
 }

--- a/examples/src/test/java/org/reactivestreams/example/unicast/SyncSubscriberTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/SyncSubscriberTest.java
@@ -1,17 +1,14 @@
 package org.reactivestreams.example.unicast;
 
-import java.util.Collections;
-import java.util.Iterator;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.tck.SubscriberBlackboxVerification;
 import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.AfterClass;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Test // Must be here for TestNG to find and run this, do not remove
 public class SyncSubscriberTest extends SubscriberBlackboxVerification<Integer> {
@@ -39,9 +36,8 @@ public class SyncSubscriberTest extends SubscriberBlackboxVerification<Integer> 
       }
     };
   }
-  @SuppressWarnings("unchecked")
-  @Override public Publisher<Integer> createHelperPublisher(long elements) {
-    if (elements > Integer.MAX_VALUE) return new InfiniteIncrementNumberPublisher(e);
-    else return new NumberIterablePublisher(0, (int)elements, e);
+
+  @Override public Integer createElement(int element) {
+    return element;
   }
 }

--- a/tck/README.md
+++ b/tck/README.md
@@ -178,6 +178,36 @@ Subscriber rules Verification is split up into two files (styles) of tests.
 
 The Blackbox Verification tests do not require the implementation under test to be modified at all, yet they are *not* able to verify most rules. In Whitebox Verification, more control over `request()` calls etc. is required in order to validate rules more precisely.
 
+### Helper Publisher implementations
+Since testing a `Subscriber` is not possible without a corresponding `Publisher` the TCK Subscriber Verifications
+both provide a default "helper publisher" to drive its test and also alow to replace this Publisher with a custom implementation.
+
+For simple Subscribers which are able to consume elements of *any type*, it is **highly recommmended** to extend the
+SubscriberVerification (described below) classes providing the element type `java.lang.Integer`, like so: `... extends SubscriberBlackboxVerification<Integer>`.
+The reason for this is, that the TCK contains a default Publisher implementation which is able to signal `Integer` elements,
+thus alowing the implementer to strictly focus on only implementing a proper `Subscriber`, instead of having to implement
+an additional Publisher only in order to drive the Subscribers tests. This is especially important for library implementers
+which only want to implement a Subscriber – and do not want to spend time or thought on implementing a valid Publisher.
+
+If however any SubscriberVerification class is extended using a custom element type, e.g. like this `... extends SubscriberBlackboxVerification<Message>`,
+*the TCK will immediatly fail the entire subscriber test class* as it is unable to properly create signals of type `Message`
+(which can be some custom message type the `Subscriber` is able to consume). The exception thrown (`UnableToProvidePublisherException`)
+contains some information and directs the implementer towards implementing a custom helper publisher,
+which is done by overriding the `Publisher<T> createHelperPublisher(long elements)` method:
+
+```java
+@Override public Publisher<Message> createHelperPublisher(long elements) {
+  return new Publisher<Message>() { /* IMPL HERE */ };
+}
+```
+
+Summing up, we recommend implementing Subscribers which are able to consume any type of element, in this case the TCK
+should be driven using `Integer` elements as default publishers are already implemented for this type. If the
+`Subscriber` is unable to consume `Integer` elements, the implementer MUST implement a custom `Publisher<T>` that will
+be able to signal the required element types. It is of course both possible and recommended to re-use existing
+implemenations (which can be seen in the examples sub-project) to create these custom Publishers – an example of
+such re-use can be found in [ProvidedHelperPublisherForSubscriberVerificationTest#createStringPublisher](https://github.com/reactive-streams/reactive-streams/blob/master/tck/src/test/java/org/reactivestreams/tck/ProvidedHelperPublisherForSubscriberVerificationTest.java#L215)
+
 ### Subscriber Blackbox Verification
 
 Blackbox Verification does not require any additional work except from providing a `Subscriber` and `Publisher` instances to the TCK:
@@ -202,11 +232,6 @@ public class MySubscriberBlackboxVerificationTest extends SubscriberBlackboxVeri
   @Override
   public Subscriber<Integer> createSubscriber() {
     return new MySubscriber<Integer>();
-  }
-
-  @Override
-  public Publisher<Integer> createHelperPublisher(long elements) {
-    return new MyRangePublisher<Integer>(1, elements);
   }
 }
 ```
@@ -281,11 +306,6 @@ public class MySubscriberWhiteboxVerificationTest extends SubscriberWhiteboxVeri
         probe.registerOnComplete();
       }
     };
-  }
-
-  @Override
-  public Publisher<Integer> createHelperPublisher(long elements) {
-    return new MyRangePublisher<Integer>(1, elements);
   }
 
 }

--- a/tck/build.gradle
+++ b/tck/build.gradle
@@ -2,5 +2,6 @@ description = 'reactive-streams-tck'
 dependencies {
     compile group: 'org.testng', name: 'testng', version:'5.14.10'
     compile project(':reactive-streams')
+    compile project(':reactive-streams-examples')
 }
 test.useTestNG()

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 import java.util.HashSet;
 import java.util.Set;
 
-public abstract class IdentityProcessorVerification<T> {
+public abstract class IdentityProcessorVerification<T> extends WithHelperPublisher<T> {
 
   private final TestEnvironment env;
 
@@ -64,6 +64,10 @@ public abstract class IdentityProcessorVerification<T> {
         return IdentityProcessorVerification.this.createSubscriber(probe);
       }
 
+      @Override public T createElement(int element) {
+        return IdentityProcessorVerification.this.createElement(element);
+      }
+
       @Override
       public Publisher<T> createHelperPublisher(long elements) {
         return IdentityProcessorVerification.this.createHelperPublisher(elements);
@@ -108,15 +112,24 @@ public abstract class IdentityProcessorVerification<T> {
   public abstract Processor<T, T> createIdentityProcessor(int bufferSize);
 
   /**
-   * Helper method required for running the Publisher rules against a Publisher.
-   * It must create a Publisher for a stream with exactly the given number of elements.
-   * If {@code elements} is {@code Long.MAX_VALUE} the produced stream must be infinite.
-   *
-   * The stream must not produce the same element twice (in case of an infinite stream this requirement
-   * is relaxed to only apply to the elements that are actually requested during all tests).
-   *
-   * @param elements exact number of elements this publisher should emit,
-   *                 unless equal to {@code Long.MAX_VALUE} in which case the stream should be effectively infinite
+   * Helper method required for creating the Publisher to which the tested Subscriber will be subscribed and tested against.
+   * <p>
+   * By default an <b>asynchronously signalling Publisher</b> is provided, which will use
+   * {@link org.reactivestreams.tck.SubscriberBlackboxVerification#createElement(int)} to generate elements type
+   * your Subscriber is able to consume.
+   * <p>
+   * Sometimes you may want to implement your own custom custom helper Publisher - to validate behaviour of a Subscriber
+   * when facing a synchronous Publisher for example. If you do, it MUST emit the exact number of elements asked for
+   * (via the {@code elements} parameter) and MUST also must treat the following numbers of elements in these specific ways:
+   * <ul>
+   *   <li>
+   *     If {@code elements} is {@code Long.MAX_VALUE} the produced stream must be infinite.
+   *   </li>
+   *   <li>
+   *     If {@code elements} is {@code 0} the {@code Publisher} should signal {@code onComplete} immediatly.
+   *     In other words, it should represent a "completed stream".
+   *   </li>
+   * </ul>
    */
   public abstract Publisher<T> createHelperPublisher(long elements);
 

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -8,8 +8,13 @@ import org.reactivestreams.tck.TestEnvironment.ManualSubscriber;
 import org.reactivestreams.tck.support.Optional;
 import org.reactivestreams.tck.support.TestException;
 import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.reactivestreams.tck.Annotations.NotVerified;
 import static org.reactivestreams.tck.Annotations.Required;
@@ -26,7 +31,7 @@ import static org.reactivestreams.tck.SubscriberWhiteboxVerification.BlackboxSub
  * @see org.reactivestreams.Subscriber
  * @see org.reactivestreams.Subscription
  */
-public abstract class SubscriberBlackboxVerification<T> {
+public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublisher<T> {
 
   private final TestEnvironment env;
 
@@ -34,28 +39,24 @@ public abstract class SubscriberBlackboxVerification<T> {
     this.env = env;
   }
 
+  // USER API
+
   /**
    * This is the main method you must implement in your test incarnation.
    * It must create a new {@link org.reactivestreams.Subscriber} instance to be subjected to the testing logic.
    */
   public abstract Subscriber<T> createSubscriber();
 
+  // ENV SETUP
+
   /**
-   * Helper method required for generating test elements.
-   * It must create a {@link org.reactivestreams.Publisher} for a stream with exactly the given number of elements.
-   * <p>
-   * It also must treat the following numbers of elements in these specific ways:
-   * <ul>
-   *   <li>
-   *    If {@code elements} is {@code Long.MAX_VALUE} the produced stream must be infinite.
-   *   </li>
-   *   <li>
-   *    If {@code elements} is {@code 0} the {@code Publisher} should signal {@code onComplete} immediatly.
-   *    In other words, it should represent a "completed stream".
-   *   </li>
-   * </ul>
+   * Executor service used by the default provided asynchronous Publisher.
+   * @see #createHelperPublisher(long)
    */
-  public abstract Publisher<T> createHelperPublisher(long elements);
+  private ExecutorService publisherExecutor;
+  @BeforeClass public void startPublisherExecutorService() { publisherExecutor = Executors.newFixedThreadPool(4); }
+  @AfterClass public void shutdownPublisherExecutorService() { if (publisherExecutor != null) publisherExecutor.shutdown(); }
+  @Override public ExecutorService publisherExecutorService() { return publisherExecutor; }
 
   ////////////////////// TEST ENV CLEANUP /////////////////////////////////////
 

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -15,6 +15,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.reactivestreams.tck.Annotations.NotVerified;
 import static org.reactivestreams.tck.Annotations.Required;
@@ -224,7 +225,24 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
       @Override
       public void run(BlackboxTestStage stage) throws Throwable {
-        final Publisher<T> pub = createHelperPublisher(0);
+        final Publisher<T> pub = new Publisher<T>() {
+          @Override public void subscribe(final Subscriber<? super T> s) {
+            s.onSubscribe(new Subscription() {
+              private boolean completed = false;
+
+              @Override public void request(long n) {
+                if (!completed) {
+                  completed = true;
+                  s.onComplete(); // Publisher now realises that it is in fact already completed
+                }
+              }
+
+              @Override public void cancel() {
+                // noop, ignore
+              }
+            });
+          }
+        };
 
         final Subscriber<T> sub = createSubscriber();
         final BlackboxSubscriberProxy<T> probe = stage.createBlackboxSubscriberProxy(env, sub);

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -5,12 +5,16 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.Annotations.Additional;
 import org.reactivestreams.tck.TestEnvironment.*;
-import org.reactivestreams.tck.support.Function;
 import org.reactivestreams.tck.support.Optional;
 import org.reactivestreams.tck.support.TestException;
 import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.reactivestreams.tck.Annotations.NotVerified;
 import static org.reactivestreams.tck.Annotations.Required;
@@ -23,13 +27,15 @@ import static org.testng.Assert.assertTrue;
  * @see org.reactivestreams.Subscriber
  * @see org.reactivestreams.Subscription
  */
-public abstract class SubscriberWhiteboxVerification<T> {
+public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublisher<T> {
 
   private final TestEnvironment env;
 
   protected SubscriberWhiteboxVerification(TestEnvironment env) {
     this.env = env;
   }
+
+  // USER API
 
   /**
    * This is the main method you must implement in your test incarnation.
@@ -40,33 +46,16 @@ public abstract class SubscriberWhiteboxVerification<T> {
    */
   public abstract Subscriber<T> createSubscriber(WhiteboxSubscriberProbe<T> probe);
 
-  /**
-   * Helper method required for generating test elements.
-   * It must create a {@link org.reactivestreams.Publisher} for a stream with exactly the given number of elements.
-   * <p>
-   * It also must treat the following numbers of elements in these specific ways:
-   * <ul>
-   *   <li>
-   *    If {@code elements} is {@code Long.MAX_VALUE} the produced stream must be infinite.
-   *   </li>
-   *   <li>
-   *    If {@code elements} is {@code 0} the {@code Publisher} should signal {@code onComplete} immediatly.
-   *    In other words, it should represent a "completed stream".
-   *   </li>
-   * </ul>
-   */
-  public abstract Publisher<T> createHelperPublisher(long elements);
+  // ENV SETUP
 
   /**
-   * Used to break possibly infinite wait-loops.
-   * Some Rules use the "eventually stop signalling" wording, which requires the test to spin accepting {@code onNext}
-   * signals until no more are signalled. In these tests, this value will be used as upper bound on the number of spin iterations.
-   *
-   * Override this method in case your implementation synchronously signals very large batches before reacting to cancellation (for example).
+   * Executor service used by the default provided asynchronous Publisher.
+   * @see #createHelperPublisher(long)
    */
-  public long maxOnNextSignalsInTest() {
-    return 100;
-  }
+  private ExecutorService publisherExecutor;
+  @BeforeClass public void startPublisherExecutorService() { publisherExecutor = Executors.newFixedThreadPool(4); }
+  @AfterClass public void shutdownPublisherExecutorService() { if (publisherExecutor != null) publisherExecutor.shutdown(); }
+  @Override public ExecutorService publisherExecutorService() { return publisherExecutor; }
 
   ////////////////////// TEST ENV CLEANUP /////////////////////////////////////
 

--- a/tck/src/main/java/org/reactivestreams/tck/WithHelperPublisher.java
+++ b/tck/src/main/java/org/reactivestreams/tck/WithHelperPublisher.java
@@ -1,0 +1,67 @@
+package org.reactivestreams.tck;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.support.Function;
+import org.reactivestreams.tck.support.HelperPublisher;
+import org.reactivestreams.tck.support.InfiniteHelperPublisher;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Type which is able to create elements based on a seed {@code id} value.
+ * <p>
+ * Simplest implementations will simply return the incoming id as the element.
+ *
+ * @param <T> type of element to be delivered to the Subscriber
+ */
+public abstract class WithHelperPublisher<T> {
+
+  /** ExecutorService to be used by the provided helper {@link org.reactivestreams.Publisher} */
+  public abstract ExecutorService publisherExecutorService();
+
+  /**
+   * Implement this method to match your expected element type.
+   * In case of implementing a simple Subscriber which is able to consume any kind of element simply return the
+   * incoming {@code element} element.
+   * <p/>
+   * Sometimes the Subscriber may be limited in what type of element it is able to consume, this you may have to implement
+   * this method such that the emitted element matches the Subscribers requirements. Simplest implementations would be
+   * to simply pass in the {@code element} as payload of your custom element, such as appending it to a String or other identifier.
+   *
+   * @return element of the matching type {@code T} that will be delivered to the tested Subscriber
+   */
+  public abstract T createElement(int element);
+
+  /**
+   * Helper method required for creating the Publisher to which the tested Subscriber will be subscribed and tested against.
+   * <p>
+   * By default an <b>asynchronously signalling Publisher</b> is provided, which will use
+   * {@link org.reactivestreams.tck.SubscriberBlackboxVerification#createElement(int)} to generate elements type
+   * your Subscriber is able to consume.
+   * <p>
+   * Sometimes you may want to implement your own custom custom helper Publisher - to validate behaviour of a Subscriber
+   * when facing a synchronous Publisher for example. If you do, it MUST emit the exact number of elements asked for
+   * (via the {@code elements} parameter) and MUST also must treat the following numbers of elements in these specific ways:
+   * <ul>
+   *   <li>
+   *     If {@code elements} is {@code Long.MAX_VALUE} the produced stream must be infinite.
+   *   </li>
+   *   <li>
+   *     If {@code elements} is {@code 0} the {@code Publisher} should signal {@code onComplete} immediatly.
+   *     In other words, it should represent a "completed stream".
+   *   </li>
+   * </ul>
+   */
+  @SuppressWarnings("unchecked")
+  public Publisher<T> createHelperPublisher(long elements) {
+    final Function<Integer, T> mkElement = new Function<Integer, T>() {
+      @Override public T apply(Integer id) throws Throwable {
+        return createElement(id);
+      }
+    };
+
+    if (elements > Integer.MAX_VALUE) return new InfiniteHelperPublisher(mkElement, publisherExecutorService());
+    else return new HelperPublisher(0, (int) elements, mkElement, publisherExecutorService());
+  }
+
+}

--- a/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisher.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisher.java
@@ -22,8 +22,7 @@ public class HelperPublisher<T> extends AsyncIterablePublisher<T> {
                 else try {
                   return create.apply(at++);
                 } catch (Throwable t) {
-                  throw new HelperPublisherException(
-                    String.format("Failed to create element in %s for id %s!", getClass().getSimpleName(), at - 1), t);
+                  throw new IllegalStateException(String.format("Failed to create element for id %d!", at - 1), t);
                 }
               }
               @Override public void remove() { throw new UnsupportedOperationException(); }

--- a/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisher.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisher.java
@@ -1,0 +1,34 @@
+package org.reactivestreams.tck.support;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.Executor;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.example.unicast.AsyncIterablePublisher;
+
+public class HelperPublisher<T> extends AsyncIterablePublisher<T> {
+  
+    public HelperPublisher(final int from, final int to, final Function<Integer, T> create, final Executor executor) {
+        super(new Iterable<T>() {
+          { if(from > to) throw new IllegalArgumentException("from must be equal or greater than to!"); }
+          @Override public Iterator<T> iterator() {
+            return new Iterator<T>() {
+              private int at = from;
+              @Override public boolean hasNext() { return at < to; }
+              @Override public T next() {
+                if (!hasNext()) return Collections.<T>emptyList().iterator().next();
+                else try {
+                  return create.apply(at++);
+                } catch (Throwable t) {
+                  throw new HelperPublisherException(
+                    String.format("Failed to create element in %s for id %s!", getClass().getSimpleName(), at - 1), t);
+                }
+              }
+              @Override public void remove() { throw new UnsupportedOperationException(); }
+            };
+          }
+        }, executor);
+    }
+}

--- a/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisherException.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisherException.java
@@ -1,0 +1,7 @@
+package org.reactivestreams.tck.support;
+
+public final class HelperPublisherException extends RuntimeException {
+  public HelperPublisherException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisherException.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/HelperPublisherException.java
@@ -1,7 +1,0 @@
-package org.reactivestreams.tck.support;
-
-public final class HelperPublisherException extends RuntimeException {
-  public HelperPublisherException(String message, Throwable cause) {
-    super(message, cause);
-  }
-}

--- a/tck/src/main/java/org/reactivestreams/tck/support/InfiniteHelperPublisher.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/InfiniteHelperPublisher.java
@@ -18,7 +18,7 @@ public class InfiniteHelperPublisher<T> extends AsyncIterablePublisher<T> {
                 try {
                   return create.apply(at++); // Wraps around on overflow
                 } catch (Throwable t) {
-                  throw new HelperPublisherException(
+                  throw new IllegalStateException(
                     String.format("Failed to create element in %s for id %s!", getClass().getSimpleName(), at - 1), t);
                 }
               }

--- a/tck/src/main/java/org/reactivestreams/tck/support/InfiniteHelperPublisher.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/InfiniteHelperPublisher.java
@@ -1,0 +1,30 @@
+package org.reactivestreams.tck.support;
+
+import org.reactivestreams.example.unicast.AsyncIterablePublisher;
+
+import java.util.Iterator;
+import java.util.concurrent.Executor;
+
+public class InfiniteHelperPublisher<T> extends AsyncIterablePublisher<T> {
+
+    public InfiniteHelperPublisher(final Function<Integer, T> create, final Executor executor) {
+        super(new Iterable<T>() {
+          @Override public Iterator<T> iterator() {
+            return new Iterator<T>() {
+              private int at = 0;
+
+              @Override public boolean hasNext() { return true; }
+              @Override public T next() {
+                try {
+                  return create.apply(at++); // Wraps around on overflow
+                } catch (Throwable t) {
+                  throw new HelperPublisherException(
+                    String.format("Failed to create element in %s for id %s!", getClass().getSimpleName(), at - 1), t);
+                }
+              }
+              @Override public void remove() { throw new UnsupportedOperationException(); }
+            };
+          }
+        }, executor);
+    }
+}

--- a/tck/src/test/java/org/reactivestreams/tck/IdentityProcessorVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/IdentityProcessorVerificationTest.java
@@ -28,22 +28,20 @@ public class IdentityProcessorVerificationTest extends TCKVerificationSupport {
   public void spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError_shouldBeIgnored() throws Throwable {
     requireTestSkip(new ThrowingRunnable() {
       @Override public void run() throws Throwable {
-        new IdentityProcessorVerification(newTestEnvironment(), DEFAULT_TIMEOUT_MILLIS){
-          @Override public Processor createIdentityProcessor(int bufferSize) {
+        new IdentityProcessorVerification<Integer>(newTestEnvironment(), DEFAULT_TIMEOUT_MILLIS){
+          @Override public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
             return new NoopProcessor();
           }
 
           @Override public ExecutorService publisherExecutorService() { return ex; }
 
-          @Override public Object createElement(int element) {
-            return null;
-          }
+          @Override public Integer createElement(int element) { return element; }
 
-          @Override public Publisher createHelperPublisher(long elements) {
+          @Override public Publisher<Integer> createHelperPublisher(long elements) {
             return SKIP;
           }
 
-          @Override public Publisher createErrorStatePublisher() {
+          @Override public Publisher<Integer> createErrorStatePublisher() {
             return SKIP;
           }
 

--- a/tck/src/test/java/org/reactivestreams/tck/SubscriberBlackboxVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/SubscriberBlackboxVerificationTest.java
@@ -1,13 +1,14 @@
 package org.reactivestreams.tck;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.support.TCKVerificationSupport;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
 * Validates that the TCK's {@link org.reactivestreams.tck.SubscriberBlackboxVerification} fails with nice human readable errors.
@@ -16,6 +17,10 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SubscriberBlackboxVerificationTest extends TCKVerificationSupport {
 
   static final int DEFAULT_TIMEOUT_MILLIS = 100;
+
+  private ExecutorService ex;
+  @BeforeClass void before() { ex = Executors.newFixedThreadPool(4); }
+  @AfterClass void after() { if (ex != null) ex.shutdown(); }
 
   @Test
   public void spec201_blackbox_mustSignalDemandViaSubscriptionRequest_shouldFailBy_notGettingRequestCall() throws Throwable {
@@ -135,15 +140,17 @@ public class SubscriberBlackboxVerificationTest extends TCKVerificationSupport {
   /**
    * Verification using a Subscriber that doesn't do anything on any of the callbacks
    */
-  final SubscriberBlackboxVerification<Integer> noopSubscriberVerification() {
+  final SubscriberBlackboxVerification<Integer> noopSubscriberVerification() throws Exception {
     return new SubscriberBlackboxVerification<Integer>(newTestEnvironment()) {
       @Override public Subscriber<Integer> createSubscriber() {
         return new NoopSubscriber();
       }
 
-      @Override public Publisher<Integer> createHelperPublisher(long elements) {
-        return newSimpleIntsPublisher(elements);
+      @Override public Integer createElement(int element) {
+        return element;
       }
+
+      @Override public ExecutorService publisherExecutorService() { return ex; }
     };
   }
 
@@ -167,9 +174,9 @@ public class SubscriberBlackboxVerificationTest extends TCKVerificationSupport {
         };
       }
 
-      @Override public Publisher<Integer> createHelperPublisher(long elements) {
-        return newSimpleIntsPublisher(elements);
-      }
+      @Override public Integer createElement(int element) { return element; }
+
+      @Override public ExecutorService publisherExecutorService() { return ex; }
     };
   }
 
@@ -182,9 +189,9 @@ public class SubscriberBlackboxVerificationTest extends TCKVerificationSupport {
         return sub;
       }
 
-      @Override public Publisher<Integer> createHelperPublisher(long elements) {
-        return newSimpleIntsPublisher(elements);
-      }
+      @Override public Integer createElement(int element) { return element; }
+
+      @Override public ExecutorService publisherExecutorService() { return ex; }
     };
   }
 

--- a/tck/src/test/java/org/reactivestreams/tck/SubscriberWhiteboxVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/SubscriberWhiteboxVerificationTest.java
@@ -1,17 +1,18 @@
 package org.reactivestreams.tck;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.SubscriberWhiteboxVerification.SubscriberPuppet;
-import org.reactivestreams.tck.SubscriberWhiteboxVerification.SubscriberPuppeteer;
 import org.reactivestreams.tck.SubscriberWhiteboxVerification.WhiteboxSubscriberProbe;
 import org.reactivestreams.tck.support.Function;
 import org.reactivestreams.tck.support.TCKVerificationSupport;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Validates that the TCK's {@link SubscriberWhiteboxVerification} fails with nice human readable errors.
@@ -20,6 +21,10 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SubscriberWhiteboxVerificationTest extends TCKVerificationSupport {
 
   static final int DEFAULT_TIMEOUT_MILLIS = 100;
+
+  private ExecutorService ex;
+  @BeforeClass void before() { ex = Executors.newFixedThreadPool(4); }
+  @AfterClass void after() { if (ex != null) ex.shutdown(); }
 
   @Test
   public void spec201_mustSignalDemandViaSubscriptionRequest_shouldFailBy_notGettingRequestCall() throws Throwable {
@@ -351,9 +356,9 @@ public class SubscriberWhiteboxVerificationTest extends TCKVerificationSupport {
         };
       }
 
-      @Override public Publisher<Integer> createHelperPublisher(long elements) {
-        return newSimpleIntsPublisher(elements);
-      }
+      @Override public Integer createElement(int element) { return element; }
+
+      @Override public ExecutorService publisherExecutorService() { return ex; }
     };
   }
 
@@ -371,9 +376,9 @@ public class SubscriberWhiteboxVerificationTest extends TCKVerificationSupport {
         }
       }
 
-      @Override public Publisher<Integer> createHelperPublisher(long elements) {
-        return newSimpleIntsPublisher(elements);
-      }
+      @Override public Integer createElement(int element) { return element; }
+
+      @Override public ExecutorService publisherExecutorService() { return ex; }
     };
   }
 


### PR DESCRIPTION
This is a rather heavy PR, however it removes the need of implementing a (helper) Publisher when I'm only interested in implementing a Subscriber. This is done by providing a default implementation - based on the example implementations (reused).

The TCK automatically picks the default publisher if it is able to. If not (types don't match), it fails ASAP and tells the implementer that he/she has to implement a custom publisher (like we, until now, always forced implementers to).

Let me know what you think!

```
+ When subscriber verifications are extended using Integer
  we can use the existing publisher implementations from examples
  to drive the tests. This allows implementers who only care about
  implementing Subscribers to not care at all about implementing
  Publishers
+ In case the subscriber verification is extended using a custom signal
  type (defined as "not Integer") we do not magically generate a
  Publisher of this type, but instead fail the tests telling the
  implementer that he/she will need to implement a custom helperPublisher
  which is exactly what we have up until now always demanded from
  implementations.
+ We also provide tests to verify the test failures work as expected,
  and that the messages are indeed helpful.
+ Updated TCK README.md to clarify when to implement a custom publisher
+ fixed mistakenly added `<T>` on NumberPublisher - it is bound to Ints
+ TCK now depends on examples, as it uses the well documented async
  publisher to provide the default publisher for numbers. As well as
  in order to allow implementers to reuse those publishers when
  implementing custom Publishers to drive their Subscriber specs.
```

Refs #181
Merry :christmas_tree: ;-)