### PR TITLE
+tck #198 allow 0-length publishers to be tested

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -242,6 +242,11 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
   }
 
   @Override @Test
+  public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() throws Throwable {
+    publisherVerification.optional_spec105_emptyStreamMustTerminateBySignallingOnComplete();
+  }
+
+  @Override @Test
   public void untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled() throws Throwable {
     publisherVerification.untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled();
   }

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -179,7 +179,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
 
   @Override @Test
   public void required_validate_maxElementsFromPublisher() throws Exception {
-    assertTrue(maxElementsFromPublisher() > 0, "maxElementsFromPublisher MUST return a number > 0");
+    assertTrue(maxElementsFromPublisher() >= 0, "maxElementsFromPublisher MUST return a number >= 0");
   }
 
   @Override @Test
@@ -378,6 +378,20 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
         sub.requestNextElement();
         sub.requestNextElement();
         sub.requestEndOfStream();
+        sub.expectNone();
+      }
+    });
+  }
+
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.5
+  @Override @Test
+  public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() throws Throwable {
+    optionalActivePublisherTest(0, true, new PublisherTestRun<T>() {
+      @Override
+      public void run(Publisher<T> pub) throws Throwable {
+        ManualSubscriber<T> sub = env.newManualSubscriber(pub);
+        sub.request(1);
+        sub.expectCompletion();
         sub.expectNone();
       }
     });

--- a/tck/src/main/java/org/reactivestreams/tck/support/PublisherVerificationRules.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/PublisherVerificationRules.java
@@ -1,7 +1,6 @@
 package org.reactivestreams.tck.support;
 
 
-
 /**
  * Internal TCK use only.
  * Add / Remove tests for PublisherVerification here to make sure that they arre added/removed in the other places.
@@ -16,6 +15,7 @@ public interface PublisherVerificationRules {
   void stochastic_spec103_mustSignalOnMethodsSequentially() throws Throwable;
   void optional_spec104_mustSignalOnErrorWhenFails() throws Throwable;
   void required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates() throws Throwable;
+  void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() throws Throwable;
   void untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled() throws Throwable;
   void required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled() throws Throwable;
   void untested_spec107_mustNotEmitFurtherSignalsOnceOnErrorHasBeenSignalled() throws Throwable;

--- a/tck/src/test/java/org/reactivestreams/tck/EmptyLazyPublisherTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/EmptyLazyPublisherTest.java
@@ -1,0 +1,42 @@
+package org.reactivestreams.tck;
+
+import org.reactivestreams.example.unicast.AsyncIterablePublisher;
+import org.reactivestreams.Publisher;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Test
+public class EmptyLazyPublisherTest extends PublisherVerification<Integer> {
+
+  private ExecutorService ex;
+
+  public EmptyLazyPublisherTest() {
+    super(new TestEnvironment());
+  }
+
+  @BeforeClass
+  void before() { ex = Executors.newFixedThreadPool(4); }
+
+  @AfterClass
+  void after() { if (ex != null) ex.shutdown(); }
+
+  @Override
+  public Publisher<Integer> createPublisher(long elements) {
+    return new AsyncIterablePublisher<Integer>(Collections.<Integer>emptyList(), ex);
+  }
+
+  @Override
+  public Publisher<Integer> createErrorStatePublisher() {
+    return null;
+  }
+
+  @Override
+  public long maxElementsFromPublisher() {
+    return 0;
+  }
+}

--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -185,6 +185,35 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
   }
 
   @Test
+  public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete_shouldNotAllowEagerOnComplete() throws Throwable {
+    final Publisher<Integer> illegalEmptyEagerOnCompletePublisher = new Publisher<Integer>() {
+      @Override public void subscribe(final Subscriber<? super Integer> s) {
+        s.onComplete();
+      }
+    };
+
+    requireTestFailure(new ThrowingRunnable() {
+      @Override public void run() throws Throwable {
+        PublisherVerification<Integer> verification = new PublisherVerification<Integer>(newTestEnvironment()) {
+          @Override public Publisher<Integer> createPublisher(long elements) {
+            return illegalEmptyEagerOnCompletePublisher;
+          }
+
+          @Override public long maxElementsFromPublisher() {
+            return 0; // it is an "empty" Publisher
+          }
+
+          @Override public Publisher<Integer> createErrorStatePublisher() {
+            return null;
+          }
+        };
+
+        verification.optional_spec105_emptyStreamMustTerminateBySignallingOnComplete();
+      }
+    }, "Subscriber::onComplete() called before Subscriber::onSubscribe");
+  }
+
+  @Test
   public void required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled_shouldFailForNotCompletingPublisher() throws Throwable {
     requireTestFailure(new ThrowingRunnable() {
       @Override public void run() throws Throwable {

--- a/tck/src/test/java/org/reactivestreams/tck/SingleElementPublisherTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/SingleElementPublisherTest.java
@@ -1,0 +1,42 @@
+package org.reactivestreams.tck;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.example.unicast.AsyncIterablePublisher;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Test
+public class SingleElementPublisherTest extends PublisherVerification<Integer> {
+
+  private ExecutorService ex;
+
+  public SingleElementPublisherTest() {
+    super(new TestEnvironment());
+  }
+
+  @BeforeClass
+  void before() { ex = Executors.newFixedThreadPool(4); }
+
+  @AfterClass
+  void after() { if (ex != null) ex.shutdown(); }
+
+  @Override
+  public Publisher<Integer> createPublisher(long elements) {
+    return new AsyncIterablePublisher<Integer>(Collections.singleton(1), ex);
+  }
+
+  @Override
+  public Publisher<Integer> createErrorStatePublisher() {
+    return null;
+  }
+
+  @Override
+  public long maxElementsFromPublisher() {
+    return 1;
+  }
+}


### PR DESCRIPTION
Adapts the TCK to allow "0 length publishers", though only one test makes sense for them AFAICS.

This PR resolves #198 and adheres to current reactive streams rules about "it must fist give out an subscription" - as seen in the call-order-schema on https://github.com/reactive-streams/reactive-streams#api-components
Though there is an open question (from my end) about if this should be explicitly mentioned in the spec itself. (See #198 for a discussion).