### PR TITLE
Fixes javadoc issues to make the build Java8 compliant

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -62,7 +62,7 @@ public class TestEnvironment {
    * run the tests.
    *
    * The default timeout for all expect* methods will be obtained by either the env variable {@code DEFAULT_TIMEOUT_MILLIS}
-   * or the default value ({@see TestEnvironment#DEFAULT_TIMEOUT_MILLIS}) will be used.
+   * or the default value ({@link TestEnvironment#DEFAULT_TIMEOUT_MILLIS}) will be used.
    *
    * @param printlnDebug if true, signals such as OnNext / Request / OnComplete etc will be printed to standard output,
    *                     often helpful to pinpoint simple race conditions etc.
@@ -78,7 +78,7 @@ public class TestEnvironment {
    * run the tests.
    *
    * The default timeout for all expect* methods will be obtained by either the env variable {@code DEFAULT_TIMEOUT_MILLIS}
-   * or the default value ({@see TestEnvironment#DEFAULT_TIMEOUT_MILLIS}) will be used.
+   * or the default value ({@link TestEnvironment#DEFAULT_TIMEOUT_MILLIS}) will be used.
    */
   public TestEnvironment() {
     this(envDefaultTimeoutMillis());

--- a/tck/src/main/java/org/reactivestreams/tck/WithHelperPublisher.java
+++ b/tck/src/main/java/org/reactivestreams/tck/WithHelperPublisher.java
@@ -23,11 +23,11 @@ public abstract class WithHelperPublisher<T> {
    * Implement this method to match your expected element type.
    * In case of implementing a simple Subscriber which is able to consume any kind of element simply return the
    * incoming {@code element} element.
-   * <p/>
+   * <p>
    * Sometimes the Subscriber may be limited in what type of element it is able to consume, this you may have to implement
    * this method such that the emitted element matches the Subscribers requirements. Simplest implementations would be
    * to simply pass in the {@code element} as payload of your custom element, such as appending it to a String or other identifier.
-   * <p/>
+   * <p>
    * <b>Warning:</b> This method may be called concurrently by the helper publisher, thus it should be implemented in a
    * thread-safe manner.
    *


### PR DESCRIPTION
@reactive-streams/contributors This is just a bugfix PR to make RS javadoc succeed on JDK8, will merge when TravisCI clears it.